### PR TITLE
Update 1.0 and 1.2 docs for move to splintercommunity 

### DIFF
--- a/docs/1.0/conversion_status.md
+++ b/docs/1.0/conversion_status.md
@@ -1,6 +1,7 @@
 # Conversion Status
 
 <!--
+  Copyright 2024 Bitwise IO, Inc.
   Copyright 2022 Cargill Incorporated
 
   Licensed under Creative Commons Attribution 4.0 International License
@@ -12,19 +13,19 @@ This site is undergoing a transition!
 Sawtooth 1.0 documentation has not yet been converted to the new site's format.
 You can find the documentation in sphinx-doc rst format at:
 
-- <https://github.com/hyperledger/sawtooth-core/tree/1-0/docs>
+- <https://github.com/splintercommunity/sawtooth-core/tree/1-0/docs>
 
 If you wish to help contribute to the Sawtooth documentation conversion
 project, please take a few pages and convert them from sphinx-doc to Jekyll.
 A partial conversion has been done with pandoc here, and should be used as
 a starting point:
 
-- <https://github.com/hyperledger/sawtooth-docs/tree/main/docs/core/1.0>
+- <https://github.com/splintercommunity/sawtooth-docs/tree/main/docs/core/1.0>
 
 And the next step is to review/fix the pages and integrate them into the new
 1.0 documentation here:
 
-- <https://github.com/hyperledger/sawtooth-docs/tree/main/docs/1.0>
+- <https://github.com/splintercommunity/sawtooth-docs/tree/main/docs/1.0>
 
 A typical page conversion PR consists of the following steps:
 
@@ -32,7 +33,7 @@ A typical page conversion PR consists of the following steps:
 - Commit 2: Update the file's markup (link syntax, note syntax, etc.) to work
   with Jekyll
 - Commit 3: Link to the file in the sidebar by updating
-  [_includes/1.0/left_sidebar.html](https://github.com/hyperledger/sawtooth-docs/blob/main/_includes/1.0/left_sidebar.html)
+  [_includes/1.0/left_sidebar.html](https://github.com/splintercommunity/sawtooth-docs/blob/main/_includes/1.0/left_sidebar.html)
 
 When submitting PRs, please keep file moves, content conversion, and content
 changes as separate commits for easier review. Thanks!

--- a/docs/1.2/app_developers_guide/address_and_namespace.md
+++ b/docs/1.2/app_developers_guide/address_and_namespace.md
@@ -1,6 +1,6 @@
 # Address and Namespace Design
 
-Hyperledger Sawtooth stores data in a Merkle-Radix tree. Data is stored
+Sawtooth stores data in a Merkle-Radix tree. Data is stored
 in leaf nodes, and each node is accessed using an addressing scheme that
 is composed of 35 bytes, represented as 70 hex characters. The
 recommended way to construct an address is to use the hex-encoded hash

--- a/docs/1.2/app_developers_guide/creating_sawtooth_network.md
+++ b/docs/1.2/app_developers_guide/creating_sawtooth_network.md
@@ -39,9 +39,7 @@ the network.
 >
 > The example environment includes the Sawtooth REST API on all validator
 > nodes. However, an application could provide a custom REST API (or no
-> REST API). See [Sawtooth Supply
-> Chain](https://github.com/hyperledger/sawtooth-supply-chain) for an
-> example of a custom REST API.
+> REST API).
 >
 > This environment also runs a consensus engine on each node. The
 > consensus engine could run on a separate system, as long as it is
@@ -199,9 +197,9 @@ access those settings when they join the network.
 Download the Docker Compose file for a multiple-node network.
 
 -   For PBFT, download
-    [sawtooth-default-pbft.yaml](https://github.com/hyperledger/sawtooth-core/blob/1-2/docker/compose/sawtooth-default-pbft.yaml)
+    [sawtooth-default-pbft.yaml](https://github.com/splintercommunity/sawtooth-core/blob/1-2/docker/compose/sawtooth-default-pbft.yaml)
 -   For PoET, download
-    [sawtooth-default-poet.yaml](https://github.com/hyperledger/sawtooth-core/blob/1-2/docker/compose/sawtooth-default-poet.yaml)
+    [sawtooth-default-poet.yaml](https://github.com/splintercommunity/sawtooth-core/blob/1-2/docker/compose/sawtooth-default-poet.yaml)
 
 ### Step 2: Start the Sawtooth Network
 
@@ -699,9 +697,9 @@ Download the Kubernetes configuration (kubeconfig) file for a Sawtooth
 network.
 
 -   For PBFT, download
-    [sawtooth-kubernetes-default-pbft.yaml](https://github.com/hyperledger/sawtooth-core/blob/1-2/docker/kubernetes/sawtooth-kubernetes-default-pbft.yaml)
+    [sawtooth-kubernetes-default-pbft.yaml](https://github.com/splintercommunity/sawtooth-core/blob/1-2/docker/kubernetes/sawtooth-kubernetes-default-pbft.yaml)
 -   For PoET, download
-    [sawtooth-kubernetes-default-poet.yaml](https://github.com/hyperledger/sawtooth-core/blob/1-2/docker/kubernetes/sawtooth-kubernetes-default-poet.yaml)
+    [sawtooth-kubernetes-default-poet.yaml](https://github.com/splintercommunity/sawtooth-core/blob/1-2/docker/kubernetes/sawtooth-kubernetes-default-poet.yaml)
 
 The kubeconfig file creates a Sawtooth network with five pods, each
 running a Sawtooth node. It also specifies the container images to
@@ -725,8 +723,8 @@ starts.
 
 2.  Download the following files:
 
-    -   [sawtooth-create-pbft-keys.yaml](https://github.com/hyperledger/sawtooth-core/blob/1-2/docker/kubernetes/sawtooth-create-pbft-keys.yaml)
-    -   [pbft-keys-configmap.yaml](https://github.com/hyperledger/sawtooth-core/blob/1-2/docker/kubernetes/pbft-keys-configmap.yaml)
+    -   [sawtooth-create-pbft-keys.yaml](https://github.com/splintercommunity/sawtooth-core/blob/1-2/docker/kubernetes/sawtooth-kubernetes-default-poet.yaml)
+    -   [pbft-keys-configmap.yaml](https://github.com/splintercommunity/sawtooth-core/blob/1-2/docker/kubernetes/pbft-keys-configmap.yaml)
 
     Save these files in the same directory where you saved
     `sawtooth-kubernetes-default-pbft.yaml...` (in the previous step).
@@ -1429,7 +1427,7 @@ Reference](http://api.zeromq.org/4-2:zmq-tcp).
 
 ### Step 1: Install Sawtooth on All Nodes
 
-Use these steps on each system to install Hyperledger Sawtooth.
+Use these steps on each system to install Sawtooth.
 
 > **Note**
 >
@@ -1754,7 +1752,7 @@ in the initial network.
         >
         >
         > This example shows the default PoET settings. For more
-        > information, see the [Hyperledger Sawtooth Settings
+        > information, see the [Sawtooth Settings
         > FAQ]({% link faq/settings.md%}).
 
 7.  As the sawtooth user, combine the separate batches into a single

--- a/docs/1.2/app_developers_guide/event_subscriptions.md
+++ b/docs/1.2/app_developers_guide/event_subscriptions.md
@@ -5,7 +5,7 @@ want to receive information on events such as the creation of a new
 block or switching to a new fork. This includes application-specific
 events that are defined by a custom transaction family.
 
-Hyperledger Sawtooth supports creating and broadcasting events. Event
+Sawtooth supports creating and broadcasting events. Event
 subscription allows an application to perform the following functions:
 
 -   Subscribe to events that occur related to the blockchain
@@ -18,12 +18,7 @@ An application can react immediately to each event or store event data
 for later processing and analysis. For example, a
 [state delta processor](#sawtoothstate-delta) could store state data in a
 reporting database for analysis and processing, which provides access to state
-information without the delay of requesting state data from the validator. For
-examples, see the [Sawtooth Supply
-Chain](https://github.com/hyperledger/sawtooth-supply-chain) or
-[Sawtooth
-Marketplace](https://github.com/hyperledger/sawtooth-marketplace)
-repository.
+information without the delay of requesting state data from the validator.
 
 This section describes the structure of events and event subscriptions,
 then explains how to use the validator's [ZeroMQ](http://zeromq.org)
@@ -337,7 +332,7 @@ WebSockets]({% link docs/1.2/rest_api/state_delta_websockets.md%}).
 
 ## Using ZMQ to Subscribe to Events
 
-Client applications can subscribe to Hyperledger Sawtooth events using
+Client applications can subscribe to Sawtooth events using
 the validator\'s [ZMQ](http://zeromq.org) messaging protocol. The
 general subscription process is as follows:
 

--- a/docs/1.2/app_developers_guide/index.md
+++ b/docs/1.2/app_developers_guide/index.md
@@ -2,7 +2,7 @@
 
 
 This guide describes how to develop applications which run on top of the
-Hyperledger Sawtooth core platform, primarily through the
+Sawtooth core platform, primarily through the
 use of Sawtooth's provided SDKs and `REST API`.
 
 Topics include an overview of Sawtooth transaction families setting up an

--- a/docs/1.2/app_developers_guide/installing_sawtooth.md
+++ b/docs/1.2/app_developers_guide/installing_sawtooth.md
@@ -1,6 +1,6 @@
 # Setting Up a Sawtooth Node for Testing
 
-Before you can start developing for the *Hyperledger Sawtooth* platform,
+Before you can start developing for the *Sawtooth* platform,
 you'll need to set up a local Sawtooth node to test your application
 against. Once the node is running, you will be able to submit new
 transactions and fetch the resulting state and block data from the
@@ -26,7 +26,7 @@ To get started, choose the guide for the platform of your choice.
 
 ## Using Docker for a Single Sawtooth Node
 
-This procedure explains how to set up Hyperledger Sawtooth for
+This procedure explains how to set up Sawtooth for
 application development using a multi-container Docker environment. It
 shows you how to start Sawtooth and connect to the necessary Docker
 containers, then walks you through the following tasks:
@@ -115,7 +115,7 @@ client commands.
 ### Step 1: Download the Sawtooth Docker Compose File
 
 Download the Docker Compose file for the Sawtooth environment,
-[sawtooth-default.yaml](https://github.com/hyperledger/sawtooth-core/blob/1-2/docker/compose/sawtooth-default.yaml).
+[sawtooth-default.yaml](https://github.com/splintercommunity/sawtooth-core/blob/1-2/docker/compose/sawtooth-default.yaml).
 
 This example Compose file defines the process for constructing a simple
 Sawtooth environment with following containers:
@@ -630,7 +630,7 @@ for any reason.
 
 ## Using Kubernetes for a Single Sawtooth Node
 
-This procedure explains how to create a single Hyperledger Sawtooth
+This procedure explains how to create a single Sawtooth
 validator node with
 [Kubernetes](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/).
 This environment uses
@@ -804,7 +804,7 @@ Minikube](https://kubernetes.io/docs/setup/minikube/).
 
 Download the Kubernetes configuration file for a single-node
 environment:
-[sawtooth-kubernetes-default.yaml](https://github.com/hyperledger/sawtooth-core/blob/1-2/docker/kubernetes/sawtooth-kubernetes-default.yaml).
+[sawtooth-kubernetes-default.yaml](https://github.com/splintercommunity/sawtooth-core/blob/1-2/docker/kubernetes/sawtooth-kubernetes-default.yaml).
 
 This file defines the process for constructing a one-node Sawtooth
 environment with following containers:
@@ -1323,7 +1323,7 @@ Use the following commands to stop and reset the Sawtooth environment.
 
 ## Using Ubuntu for a Single Sawtooth Node
 
-This procedure explains how to set up Hyperledger Sawtooth for
+This procedure explains how to set up Sawtooth for
 application development on Ubuntu 18.04 (Bionic). It shows you how to
 install Sawtooth on Ubuntu, then walks you through the following tasks:
 
@@ -1568,7 +1568,7 @@ Use the same terminal window as the previous step.
     output will be similar to this truncated example:
 
     ``` console
-    [2018-03-14 15:53:34.909 INFO     cli] sawtooth-validator (Hyperledger Sawtooth) version 1.0.1
+    [2018-03-14 15:53:34.909 INFO     cli] sawtooth-validator (Sawtooth) version 1.0.1
     [2018-03-14 15:53:34.909 INFO     path] Skipping path loading from non-existent config file: /etc/sawtooth/path.toml
     [2018-03-14 15:53:34.910 INFO     validator] Skipping validator config loading from non-existent config file: /etc/sawtooth/validator.toml
     [2018-03-14 15:53:34.911 INFO     keys] Loading signing key: /home/username/.sawtooth/keys/my_key.priv

--- a/docs/1.2/app_developers_guide/intro_xo_transaction_family.md
+++ b/docs/1.2/app_developers_guide/intro_xo_transaction_family.md
@@ -29,7 +29,7 @@ The XO transaction family includes:
 
 > -   Transaction processors in several languages, including Go
 >     (`xo-tp-go`),
->     [JavaScript](https://github.com/hyperledger/sawtooth-sdk-javascript/blob/master/examples/xo/),
+>     [JavaScript](https://github.com/splintercommunity/sawtooth-sdk-javascript/blob/master/examples/xo/),
 >     and Python (`xo-tp-python`). These transaction processors
 >     implement the business logic of XO game play.
 > -   An `xo` client: A set of commands that provide a command-line

--- a/docs/1.2/app_developers_guide/no_sdk.md
+++ b/docs/1.2/app_developers_guide/no_sdk.md
@@ -1,6 +1,6 @@
 # Development Without an SDK
 
-Hyperledger Sawtooth provides SDKs in a variety of languages to handle a
+Sawtooth provides SDKs in a variety of languages to handle a
 great deal of complexity and simplify developing applications for this
 platform. The recommended way to work with Sawtooth is through
 one of these [SDKs]({%link docs/1.2/app_developers_guide/using_the_sdks.md %}).

--- a/docs/1.2/app_developers_guide/python_sdk.md
+++ b/docs/1.2/app_developers_guide/python_sdk.md
@@ -44,7 +44,7 @@ Sawtooth batches.
 > implementation.
 
 For a full Python implementation see,  the [XO transaction
-family](https://github.com/hyperledger/sawtooth-sdk-python/tree/master/examples/xo_python)
+family](https://github.com/splintercommunity/sawtooth-sdk-python/tree/main/examples/xo_python)
 
 ## Prerequisites
 
@@ -630,7 +630,7 @@ return XO_NAMESPACE + \
 
 The process of encoding information to be submitted to a distributed
 ledger is generally non-trivial. A series of cryptographic safeguards
-are used to confirm identity and data validity. Hyperledger Sawtooth is
+are used to confirm identity and data validity. Sawtooth is
 no different, but the Python SDK does provide client
 functionality that abstracts away most of these details, and greatly
 simplifies the process of making changes to the blockchain.

--- a/docs/1.2/app_developers_guide/rust_sdk.md
+++ b/docs/1.2/app_developers_guide/rust_sdk.md
@@ -35,7 +35,7 @@ implements XO, a distributed version of the two-player game
 
 
 For a full Rust implementation see the [XO transaction
-family](https://github.com/hyperledger/sawtooth-sdk-rust/tree/master/examples/xo_rust)
+family](https://github.com/splintercommunity/sawtooth-sdk-rust/tree/main/examples/xo_rust)
 
 
 ## Prerequisites
@@ -68,7 +68,7 @@ Sawtooth in Rust.
 1.  Add Sawtooth to your `Cargo.toml` file. Add sawtooth-sdk with the
     appropriate version to the dependencies section. The Rust SDK is
     located in the Sawtooth SDK Rust repository
-    <http://github.com/hyperledger/sawtooth-sdk-rust>.
+    <http://github.com/splintercommunity/sawtooth-sdk-rust>.
 
 ```ini
 [package]
@@ -142,7 +142,7 @@ fn main() {
 >
 > If you\'re looking for a working implementation of an XO transaction
 > processor in Rust, check out the [xo_rust
-> example](https://github.com/hyperledger/sawtooth-sdk-rust/tree/master/examples/xo_rust)
+> example](https://github.com/splintercommunity/sawtooth-sdk-rust/tree/main/examples/xo_rust)
 > in the Rust SDK repository.
 
 
@@ -690,7 +690,7 @@ pub fn calculate_address(name: &str) -> String {
 
 The process of encoding information to be submitted to a distributed
 ledger is generally non-trivial. A series of cryptographic safeguards
-are used to confirm identity and data validity. Hyperledger Sawtooth is
+are used to confirm identity and data validity. Sawtooth is
 no different, but the Rust SDK does provide client
 functionality that abstracts away most of these details, and greatly
 simplifies the process of making changes to the blockchain.

--- a/docs/1.2/app_developers_guide/using_the_sdks.md
+++ b/docs/1.2/app_developers_guide/using_the_sdks.md
@@ -8,19 +8,19 @@ development.
 The Sawtooth SDKs are in the following repositories:
 
 -   C++:
-    [hyperledger/sawtooth-sdk-cxx](https://github.com/hyperledger/sawtooth-sdk-cxx)
+    [splintercommunity/sawtooth-sdk-cxx](https://github.com/splintercommunity/sawtooth-sdk-cxx)
 -   Go:
-    [hyperledger/sawtooth-sdk-go](https://github.com/hyperledger/sawtooth-sdk-go)
+    [splintercommunity/sawtooth-sdk-go](https://github.com/splintercommunity/sawtooth-sdk-go)
 -   Java:
-    [hyperledger/sawtooth-sdk-java](https://github.com/hyperledger/sawtooth-sdk-java)
+    [splintercommunity/sawtooth-sdk-java](https://github.com/splintercommunity/sawtooth-sdk-java)
 -   JavaScript:
-    [hyperledger/sawtooth-sdk-javascript](https://github.com/hyperledger/sawtooth-sdk-javascript)
+    [splintercommunity/sawtooth-sdk-javascript](https://github.com/splintercommunity/sawtooth-sdk-javascript)
 -   Python:
-    [hyperledger/sawtooth-sdk-python](https://github.com/hyperledger/sawtooth-sdk-python)
+    [splintercommunity/sawtooth-sdk-python](https://github.com/splintercommunity/sawtooth-sdk-python)
 -   Rust:
-    [hyperledger/sawtooth-sdk-rust](https://github.com/hyperledger/sawtooth-sdk-rust)
+    [splintercommunity/sawtooth-sdk-rust](https://github.com/splintercommunity/sawtooth-sdk-rust)
 -   Swift:
-    [hyperledger/sawtooth-sdk-swift](https://github.com/hyperledger/sawtooth-sdk-swift)
+    [splintercommunity/sawtooth-sdk-swift](https://github.com/splintercommunity/sawtooth-sdk-swift)
 
 The following table summarizes the Sawtooth SDKs. It shows the feature
 completeness, API stability, and maturity level for the client signing,

--- a/docs/1.2/architecture/events_and_transactions_receipts.md
+++ b/docs/1.2/architecture/events_and_transactions_receipts.md
@@ -1,6 +1,6 @@
 # Events and Transaction Receipts
 
-Hyperledger Sawtooth supports creating and broadcasting events. This
+Sawtooth supports creating and broadcasting events. This
 allows applications to do the following:
 
 - Subscribe to events that occur related to the blockchain, such as a

--- a/docs/1.2/architecture/index.md
+++ b/docs/1.2/architecture/index.md
@@ -1,10 +1,9 @@
 # Architecture Guide
 
-
 The following diagram shows a high-level view of the Sawtooth
 architecture.
 
-This guide describes the design and architecture of Hyperledger
+This guide describes the design and architecture of
 Sawtooth, an enterprise blockchain platform for building distributed
 ledger applications and networks.
 

--- a/docs/1.2/architecture/permissioning_requirement.md
+++ b/docs/1.2/architecture/permissioning_requirement.md
@@ -1,7 +1,7 @@
 # Permissioning Design
 
 Sawtooth includes the ability to control validator and transactor
-permissions. This chapter describes permissioning in Hyperledger
+permissions. This chapter describes permissioning in
 Sawtooth by providing a detailed list of the requirements, capabilities,
 and user stories that help to understand permissioning design.
 

--- a/docs/1.2/architecture/rest_api.md
+++ b/docs/1.2/architecture/rest_api.md
@@ -5,7 +5,7 @@
 
 # REST API
 
-Hyperledger Sawtooth provides a REST API (see the [REST API Reference]({% link
+Sawtooth provides a REST API (see the [REST API Reference]({% link
 docs/1.2/rest_api/index.md %})) that allows clients to interact with a validator
 using common HTTP/JSON standards. It is a pragmatic RESTful API that provides a
 language-neutral interface for submitting transactions and reading blocks.

--- a/docs/1.2/architecture/transactions_and_batches.md
+++ b/docs/1.2/architecture/transactions_and_batches.md
@@ -152,7 +152,7 @@ reject the signature if it is anything other than 64 bytes.
 
 ### Transaction Family
 
-In Hyperledger Sawtooth, the set of possible transactions are defined by
+In Sawtooth, the set of possible transactions are defined by
 an extensible system called transaction families. Defining and
 implementing a new transaction family adds to the taxonomy of available
 transactions which can be applied. For example, in the language-specific

--- a/docs/1.2/conversion_status.md
+++ b/docs/1.2/conversion_status.md
@@ -12,19 +12,19 @@ This site is undergoing a transition!
 Sawtooth 1.2 documentation has not yet been completely converted to the new
 site's format.  You can find the documentation in sphinx-doc rst format at:
 
-- <https://github.com/hyperledger/sawtooth-core/tree/1-2/docs>
+- <https://github.com/splintercommunity/sawtooth-core/tree/1-2/docs>
 
 If you wish to help contribute to the Sawtooth documentation conversion
 project, please take a few pages and convert them from sphinx-doc to Jekyll.
 A partial conversion has been done with pandoc here, and should be used as
 a starting point:
 
-- <https://github.com/hyperledger/sawtooth-docs/tree/main/docs/core/1.2>
+- <https://github.com/splintercommunity/sawtooth-docs/tree/main/docs/core/1.2>
 
 And the next step is to review/fix the pages and integrate them into the new
 1.1 documentation here:
 
-- <https://github.com/hyperledger/sawtooth-docs/tree/main/docs/1.2>
+- <https://github.com/splintercommunity/sawtooth-docs/tree/main/docs/1.2>
 
 A typical page conversion PR consists of the following steps:
 
@@ -32,7 +32,7 @@ A typical page conversion PR consists of the following steps:
 - Commit 2: Update the file's markup (link syntax, note syntax, etc.) to work
   with Jekyll
 - Commit 3: Link to the file in the sidebar by updating
-  [_includes/1.2/left_sidebar.html](https://github.com/hyperledger/sawtooth-docs/blob/main/_includes/1.2/left_sidebar.html)
+  [_includes/1.2/left_sidebar.html](https://github.com/splintercommunity/sawtooth-docs/blob/main/_includes/1.2/left_sidebar.html)
 
 When submitting PRs, please keep file moves, content conversion, and content
 changes as separate commits for easier review. Thanks!

--- a/docs/1.2/glossary.md
+++ b/docs/1.2/glossary.md
@@ -1,6 +1,6 @@
 # Glossary
 
-This glossary defines Hyperledger Sawtooth terms and concepts.
+This glossary defines Sawtooth terms and concepts.
 
 batch
 
@@ -170,16 +170,6 @@ PoET consensus
     system without a Trusted Execution Environment. PoET simulator
     is also called *PoET/CFT* because it is crash fault tolerant,
     not Byzantine fault tolerant.
-
-Raft consensus
-
-: Leader-based consensus algorithm that is designed for small networks
-  with a restricted membership. Raft is crash fault tolerant, not
-  Byzantine fault tolerant, and has finality (does not fork). For more
-  information, see [Raft (computer science) on
-  Wikipedia](https://en.wikipedia.org/wiki/Raft_(computer_science))
-  and the [Sawtooth Raft
-  documentation](https://sawtooth.hyperledger.org/docs/raft/nightly/master/introduction.html).
 
 REST API
 

--- a/docs/1.2/index.md
+++ b/docs/1.2/index.md
@@ -6,7 +6,7 @@
 > information, see the [conversion status]({%
 link docs/1.2/conversion_status.md %}).
 
-Hyperledger Sawtooth is an enterprise blockchain platform for building
+Sawtooth is an enterprise blockchain platform for building
 distributed ledger applications and networks. The design philosophy
 targets keeping ledgers *distributed* and making smart contracts *safe*,
 particularly for enterprise use.
@@ -23,7 +23,7 @@ Sawtooth\'s core design allows applications to choose the transaction
 rules, permissioning, and consensus algorithms that support their unique
 business needs.
 
-Sawtooth is an open source project under the Hyperledger umbrella. For
+Sawtooth is an open source project. For
 information on how to contribute, see [Join the Sawtooth
 Community](#join-the-sawtooth-community).
 
@@ -108,7 +108,7 @@ performance over serial execution.
 
 ## Event System
 
-Hyperledger Sawtooth supports creating and broadcasting events. This
+Sawtooth supports creating and broadcasting events. This
 allows applications to:
 
 > -   Subscribe to events that occur related to the blockchain, such as
@@ -119,13 +119,6 @@ allows applications to:
 >     clients without storing that data in state.
 
 Subscriptions are submitted and serviced over a ZMQ Socket.
-
-## Ethereum Contract Compatibility with Seth
-
-The Sawtooth-Ethereum integration project, Seth, extends the
-interoperability of the Sawtooth platform to Ethereum. EVM (Ethereum
-Virtual Machine) smart contracts can be deployed to Sawtooth using the
-Seth transaction family.
 
 ## Dynamic Consensus {#dynamic-consensus-label}
 
@@ -181,10 +174,6 @@ for these algorithms:
 >         simulator is also called \"PoET/CFT\" because it is crash
 >         fault tolerant, not Byzantine fault tolerant.
 >
-> -   [Sawtooth Raft]({% link docs/1.2/raft/index.md %}) is a
->     leader-based consensus algorithm that provides crash fault
->     tolerance for a small network with restricted membership.
->
 > -   Devmode (short for \"developer mode\") is a simplified
 >     random-leader algorithm that is useful for developing and testing
 >     a transaction processor. Devmode is not recommended for multi-node
@@ -219,23 +208,19 @@ Additional transaction families provide models for specific areas:
 > -   BlockInfo - Provides a methodology for storing information about a
 >     configurable number of historic blocks.
 
-Other Hyperledger projects provide smart-contract functionality for the
+Other projects provide smart-contract functionality for the
 Sawtooth platform:
 
 > -   [Sawtooth
 >     Sabre]({% link docs/1.2/sabre/index.md %})
 >     -Implements on-chain smart contracts that are executed in a
 >     WebAssembly (WASM) virtual machine.
-> -   [Sawtooth
->     Seth]({% link docs/1.2/seth/index.md %})
->     -Supports running Ethereum Virtual Machine (EVM) smart contracts
->     on Sawtooth
 
 For more information, see
 [Transaction Family
 Specifications]({% link docs/1.2/transaction_family_specifications/index.md %})
 
-# Real-world Application Examples
+# Application Examples
 
 > -   XO: Demonstrates how to construct basic transactions by playing
 >     [Tic-tac-toe](https://en.wikipedia.org/wiki/Tic-tac-toe). The XO
@@ -243,27 +228,10 @@ Specifications]({% link docs/1.2/transaction_family_specifications/index.md %})
 >     `xo` command that allows two participants to play the game. For
 >     more information, see [XO Transaction Family]({% link
       docs/1.2/app_developers_guide/intro_xo_transaction_family.md %}).
-> -   Sawtooth Supply Chain: Demonstrates how to trace the provenance
->     and other contextual information of any asset. Supply Chain
->     provides an example application with a transaction processor,
->     custom REST API, and web app. This example application also
->     demonstrates a decentralized solution for in-browser transaction
->     signing, and illustrates how to synchronize the blockchain state
->     to a local database for complex queries. For more information, see
->     the [sawtooth-supply-chain repository on
->     GitHub](https://github.com/hyperledger/sawtooth-supply-chain).
-> -   Sawtooth Marketplace: Demonstrates how to exchange specific
->     quantities of customized assets with other users on the
->     blockchain. This example application contains a number of
->     components that, together with a Sawtooth validator, will run a
->     Sawtooth blockchain and provide a simple RESTful API to interact
->     with it. For more information, see the [sawtooth-marketplace
->     repository on
->     GitHub](https://github.com/hyperledger/sawtooth-marketplace).
 
 # Getting Started with Application Development
 
-## Try Hyperledger Sawtooth
+## Try Sawtooth
 
 The Sawtooth documentation explains how to set up a local
 validator for demonstrating Sawtooth functionality and testing an application.
@@ -291,9 +259,7 @@ models.
 
 Sawtooth provides a REST API and SDKs in several languages - including
 Python, C++, Go, Java, JavaScript, and Rust - for development of
-applications which run on top of the Sawtooth platform. In addition, you
-can write smart contracts in Solidity for use with the Seth transaction
-family.
+applications which run on top of the Sawtooth platform.
 
 For more information, see [App Developers
 Guide]({% link docs/1.2/app_developers_guide/index.md %}),
@@ -315,7 +281,7 @@ The Sawtooth software is distributed as source code with an Apache
 license. You can get the code to start building your own distributed
 ledger.
 
-> -   [sawtooth-core](https://github.com/hyperledger/sawtooth-core):
+> -   [sawtooth-core](https://github.com/splintercommunity/sawtooth-core):
 >     Contains fundamental classes used throughout the Sawtooth project,
 >     as well as the following items:
 >     -   The implementation of the validator process which runs on each
@@ -325,29 +291,20 @@ ledger.
 >     -   Dockerfiles to support development or launching a network of
 >         validators
 >     -   Source files for this documentation
-> -   [Sawtooth PBFT](https://github.com/hyperledger/sawtooth-pbft): Use
+> -   [Sawtooth PBFT](https://github.com/splintercommunity/sawtooth-pbft): Use
 >     PBFT consensus with Sawtooth
-> -   [Sawtooth PoET](https://github.com/hyperledger/sawtooth-poet): Use
+> -   [Sawtooth PoET](https://github.com/splintercommunity/sawtooth-poet): Use
 >     PoET consensus with Sawtooth
-> -   [Sawtooth Sabre](https://github.com/hyperledger/sawtooth-sabre):
+> -   [Sawtooth Sabre](https://github.com/splintercommunity/sawtooth-sabre):
 >     Run on-chain smart contracts executed in a WebAssembly virtual
 >     machine
-> -   [Sawtooth Seth](https://github.com/hyperledger/sawtooth-seth):
->     Deploy Ethereum Virtual Machine (EVM) smart contracts to Sawtooth
-> -   [Sawtooth
->     Marketplace](https://github.com/hyperledger/sawtooth-marketplace):
->     Exchange customized \"assets\" with other users on the blockchain
-> -   [Sawtooth Supply
->     Chain](https://github.com/hyperledger/sawtooth-supply-chain):
->     Trace the provenance and other contextual information of any asset
 
 ## Join the Sawtooth Community
 
-Sawtooth is an open source project under the Hyperledger umbrella. We
-welcome working with individuals and companies interested in advancing
-distributed ledger technology. Please see
-[Community]({% link community/index.md %})
-for ways to become a part of the Sawtooth community.
+Sawtooth is an open source project. We welcome working with individuals and
+companies interested in advancing distributed ledger technology. Please see
+[Community]({% link community/index.md %}) or ways to become a part of the
+Sawtooth community.
 
 # Acknowledgements
 
@@ -356,4 +313,4 @@ the OpenSSL Toolkit (<http://www.openssl.org/>).
 
 This project relies on other third-party components. For details, see
 the LICENSE and NOTICES files in the [sawtooth-core
-repository](https://github.com/hyperledger/sawtooth-core).
+repository](https://github.com/splintercommunity/sawtooth-core).

--- a/docs/1.2/pbft/architecture.md
+++ b/docs/1.2/pbft/architecture.md
@@ -161,7 +161,7 @@ consensus API, such as `BlockNew` and `BlockCommit`. These messages are
 called "updates" to distinguish them from the PBFT-specific messages.
 For more information on the consensus API's `Update` messages, see the
 [Consensus API
-RFC](https://github.com/hyperledger/sawtooth-rfcs/blob/master/text/0004-consensus-api.md#updates).
+RFC](https://github.com/splintercommunity/sawtooth-rfcs/blob/main/text/0004-consensus-api.md#updates).
 
 ```protobuf
 // Represents all common information used in a PBFT message

--- a/docs/1.2/pbft/configuring-pbft.md
+++ b/docs/1.2/pbft/configuring-pbft.md
@@ -69,7 +69,7 @@ following command-line options:
 ## PBFT On-Chain Settings {#on-chain-settings-label}
 
 Sawtooth PBFT includes on-chain settings for network-wide configuration
-on a Hyperledger Sawtooth network. These settings affect how the whole
+on a Sawtooth network. These settings affect how the whole
 network operates, so it is desirable that they be the same on all nodes.
 The [Settings transaction
 processor]({% link

--- a/docs/1.2/pbft/installing-and-running-pbft.md
+++ b/docs/1.2/pbft/installing-and-running-pbft.md
@@ -9,7 +9,7 @@ installed.
 1. Clone the PBFT repository.
 
     ```console
-    $ git clone https://github.com/hyperledger/sawtooth-pbft.git
+    $ git clone https://github.com/splintercommunity/sawtooth-pbft.git
     ```
 
 2. Run the following commands to install the dependencies for PBFT and

--- a/docs/1.2/pbft/introduction-to-sawtooth-pbft.md
+++ b/docs/1.2/pbft/introduction-to-sawtooth-pbft.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Sawtooth PBFT is a consensus engine for Hyperledger Sawtooth that
+Sawtooth PBFT is a consensus engine for Sawtooth that
 provides practical Byzantine fault tolerance.
 
 PBFT is a voting-based consensus algorithm that is:
@@ -43,8 +43,6 @@ seal* to verify block finality.
 > - "Secondary" is synonymous with "follower" and "backup"
 > - "Node" is synonymous with "server" and "replica"
 
-For implementation details, see the [rustdoc for Sawtooth
-PBFT](https://sawtooth.hyperledger.org/docs/pbft/nightly/master/pbft_doc/pbft_engine/index.html).
 
 <!--
   Licensed under Creative Commons Attribution 4.0 International License

--- a/docs/1.2/pbft/using-pbft-consensus.md
+++ b/docs/1.2/pbft/using-pbft-consensus.md
@@ -23,7 +23,7 @@ with restricted membership. It has the following requirements:
   - The PBFT consensus engine name is `pbft`.
   - The version number is in the file `sawtooth-pbft/Cargo.toml`
     (see the
-    [sawtooth-pbft](https://github.com/hyperledger/sawtooth-pbft/)
+    [sawtooth-pbft](https://github.com/splintercommunity/sawtooth-pbft/)
     repository) as `version = "{major}.{minor}.{patch}"`. Use only
     the first two digits (major and minor release numbers); omit the
     patch number. For example, if the version is 1.0.4, use `1.0`
@@ -33,7 +33,7 @@ with restricted membership. It has the following requirements:
   information, see [PBFT On Chain Settings]({% link
   docs/1.2/pbft/configuring-pbft.md %}#on-chain-settings-label).
 
-For the procedure to configure PBFT, see the Hyperledger Sawtooth
+For the procedure to configure PBFT, see the Sawtooth
 documentation:
 
 - Developers: [Creating a Sawtooth

--- a/docs/1.2/sabre/application_developer_guide.md
+++ b/docs/1.2/sabre/application_developer_guide.md
@@ -36,7 +36,7 @@ Include the Sabre SDK in the dependencies list of the Cargo.toml file.
 
 ```toml
 [dependencies]
-sabre-sdk = {git = "https://github.com/hyperledger/sawtooth-sabre"}
+sabre-sdk = {git = "https://github.com/splintercommunity/sawtooth-sabre"}
 ```
 
 The Sabre SDK provides the following required structs needed to write a
@@ -133,7 +133,7 @@ sabre-sdk = {path = "../../../sdks/rust"}
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rust-crypto = "0.2.36"
-sawtooth-sdk = {git = "https://github.com/hyperledger/sawtooth-sdk-rust"}
+sawtooth-sdk = {git = "https://github.com/splintercommunity/sawtooth-sdk-rust"}
 rustc-serialize = "0.3.22"
 log = "0.3.0"
 log4rs = "0.7.0"
@@ -237,7 +237,7 @@ pub unsafe fn entrypoint(payload: WasmPtr, signer: WasmPtr, signature: WasmPtr) 
 > decode functions had to be written for intkey multiply.
 
 For the full intkey-multiply example look at
-[`sawtooth-sabre/example/intkey_multiply/processor`](https://github.com/hyperledger/sawtooth-sabre/tree/main/example/intkey_multiply/processor).
+[`sawtooth-sabre/example/intkey_multiply/processor`](https://github.com/splintercommunity/sawtooth-sabre/tree/main/example/intkey_multiply/processor).
 
 ## Logging in a Sabre Smart Contract {#logging-in-smart-contracts}
 

--- a/docs/1.2/sabre/smart_permissions.md
+++ b/docs/1.2/sabre/smart_permissions.md
@@ -7,7 +7,7 @@ business logic; however, existing distributed ledger systems do not
 generally include a mechanism for representing organization-specific
 business logic. This paper describes a software architecture and design
 for implementing such a permissioning system for distributed ledger
-applications using Hyperledger Sawtooth and WebAssembly.
+applications using Sawtooth and WebAssembly.
 
 ## Background
 

--- a/docs/1.2/sysadmin_guide/about_dynamic_consensus.md
+++ b/docs/1.2/sysadmin_guide/about_dynamic_consensus.md
@@ -80,9 +80,9 @@ consensus type. Then submit a consensus change proposal.
    preferred blocks.
 
 2. Each administrator installs and starts the new consensus engine and
-   any related transaction processors. See [Installing Hyperledger Sawtooth]({%
+   any related transaction processors. See [Installing Sawtooth]({%
    link docs/1.2/sysadmin_guide/setting_up_sawtooth_network.md
-   %}#installing-hyperledger-sawtooth) and [Running Sawtooth as a Service]({%
+   %}#installing-sawtooth) and [Running Sawtooth as a Service]({%
    link docs/1.2/sysadmin_guide/setting_up_sawtooth_network.md
    %}#running-sawtooth-as-a-service) for these procedures.
 
@@ -231,62 +231,6 @@ Requirements:
   sawtooth.poet.key_block_claim_limit= 100000
   sawtooth.poet.ztest_minimum_win_count=999999999
   ```
-
-## Raft Consensus {#raft-consensus-label}
-
-[Sawtooth Raft]({% link docs/1.2/glossary.md %}#term-sawtooth-raft) provides a
-simple consensus algorithm that is easy to understand. It is leader-based, crash
-fault tolerant, and does not fork. For more information, see the [Raft
-documentation]({% link docs/1.2/raft/index.md %}).
-
-> **Note**
->
-> Sawtooth Raft is currently a prototype (not yet released). For more
-> information, see the
-> [sawtooth-raft](https://github.com/hyperledger/sawtooth-raft)
-> repository.
-
-Requirements:
-
-- Each node must install the Raft consensus engine package,
-  `sawtooth-raft-engine`.
-
-- Each node must run the Raft consensus engine:
-
-  - Service: `sawtooth-raft-engine.service`
-  - Executable: `raft-engine`
-
-  For more information, see
-  [Running Sawtooth as a Service]({% link
-  docs/1.2/sysadmin_guide/setting_up_sawtooth_network.md
-  %}#running-sawtooth-as-a-service).  (To start the consensus engine on the
-  command line, see [Step 5. Start Sawtooth on the First Node]({% link
-  docs/1.2/app_developers_guide/ubuntu_test_network.md %})).
-
-- Specify static peering when starting each validator. Use the
-  `--peering` option when starting the validator (see [sawtooth-validator]({%
-  link docs/1.2/cli/sawtooth-validator.md %})) or set the off-chain `peers`
-  setting in the `validator.toml` configuration file (see
-  [About Sawtooth Configuration Files]({% link
-  docs/1.2/sysadmin_guide/configuring_sawtooth.md %})).
-
-- Use these on-chain settings for Raft consensus:
-
-  ``` none
-  sawtooth.consensus.algorithm.name=raft
-  sawtooth.consensus.algorithm.version=[VERSION]
-  sawtooth.consensus.raft.peers=[VAL1KEY,VAL2KEY,...,VALnKEY]
-  ```
-
-  For the version number, see the `Cargo.toml` file. Use only the
-  first two digits (for example, `[0.1]`).
-
-  For `VALxKEY`, specify the validator public key of each node in the
-  network.
-
-- For other on-chain settings for Raft, see [Optional
-  Settings]({% link docs/1.2/raft/configuring_deploying.md %})
-  in the Raft documentation.
 
 ## Devmode Consensus {#devmode-consensus-label}
 

--- a/docs/1.2/sysadmin_guide/configure_sgx.md
+++ b/docs/1.2/sysadmin_guide/configure_sgx.md
@@ -5,7 +5,7 @@
 > PoET-SGX is currently not compatible with Sawtooth 1.1 or later. Users
 > looking to leverage PoET-SGX should remain on Sawtooth 1.0.
 
-This procedure describes how to install, configure, and run Hyperledger
+This procedure describes how to install, configure, and run
 Sawtooth with PoET simulator consensus on a system with Intel ® Software
 Guard Extensions (SGX).
 
@@ -31,7 +31,7 @@ docs/1.2/sysadmin_guide/setting_up_sawtooth_network.md %}).
 > **Important**
 >
 > You may need to update your BIOS with a security fix before running
-> Hyperledger Sawtooth with PoET. Affected versions and instructions for
+> Sawtooth with PoET. Affected versions and instructions for
 > updating can be found on [Intel\'s
 > website](https://security-center.intel.com/advisory.aspx?intelid=INTEL-SA-00076&languageid=en-fr).
 > If you\'re running an affected version, you must update the BIOS to
@@ -336,7 +336,7 @@ Add the following content to the file:
 
 ```ini
 #
-# Hyperledger Sawtooth -- Validator Configuration
+# Sawtooth -- Validator Configuration
 #
 
 # This file should exist in the defined config directory and allows

--- a/docs/1.2/sysadmin_guide/configuring_permissions.md
+++ b/docs/1.2/sysadmin_guide/configuring_permissions.md
@@ -5,7 +5,7 @@
 > These instructions have been tested on Ubuntu 18.04 (Bionic) only.
 
 This section describes the validator and transactor permissions in
-Hyperledger Sawtooth.
+Sawtooth.
 
 -   [Transactor key permissioning](#transactor-key-permissioning-label)
     controls who (which users and clients) can submit transactions and batches

--- a/docs/1.2/sysadmin_guide/configuring_sawtooth.md
+++ b/docs/1.2/sysadmin_guide/configuring_sawtooth.md
@@ -544,7 +544,7 @@ the configuration file.
 
 An example configuration file is in the `sawtooth-sdk-python` repository
 at
-`https://github.com/hyperledger/sawtooth-sdk-python/blob/master/examples/xo_python/packaging/xo.toml.example`.
+`https://github.com/splintercommunity/sawtooth-sdk-python/blob/master/examples/xo_python/packaging/xo.toml.example`.
 To create a XO transaction processor configuration file, download this
 example file to the config directory and name it `xo.toml`. Set the
 ownership and permissions to owner `root`, group `sawtooth`, and

--- a/docs/1.2/sysadmin_guide/grafana_configuration.md
+++ b/docs/1.2/sysadmin_guide/grafana_configuration.md
@@ -29,11 +29,11 @@ store the metrics data.
     state
 
 -   Download the
-    [hyperledger/sawtooth-core](https://github.com/hyperledger/sawtooth-core)
+    [splintercommunity/sawtooth-core](https://github.com/splintercommunity/sawtooth-core)
     repository from GitHub with this command:
 
     ``` console
-    $ git clone https://github.com/hyperledger/sawtooth-core.git
+    $ git clone https://github.com/splintercommunity/sawtooth-core.git
     ```
 
 ## Set Up InfluxDB
@@ -130,7 +130,7 @@ InfluxDB is used to store Sawtooth metrics data.
     a.  To get the 1.0 dashboard, either find it in the `1-0` branch at
         `sawtooth-core/docker/grafana/dashboards/sawtooth_performance.json`
         or download
-        [`sawtooth_performance.json`](https://raw.githubusercontent.com/hyperledger/sawtooth-core/1-0/docker/grafana/dashboards/sawtooth_performance.json)
+        [`sawtooth_performance.json`](https://raw.githubusercontent.com/splintercommunity/sawtooth-core/1-0/docker/grafana/dashboards/sawtooth_performance.json)
         from GitHub.
 
     b.  Click on the Grafana spiral logo and mouse over \"Dashboards\",

--- a/docs/1.2/sysadmin_guide/pbft_adding_removing_node.md
+++ b/docs/1.2/sysadmin_guide/pbft_adding_removing_node.md
@@ -44,7 +44,7 @@ You can add several nodes at the same time.
    block catch-up procedure, where it receives and commits the blocks
    that are already on the blockchain. (For details, see the [PBFT node
    catch-up
-   RFC](https://github.com/hyperledger/sawtooth-rfcs/blob/master/text/0031-pbft-node-catchup.md).)
+   RFC](https://github.com/splintercommunity/sawtooth-rfcs/blob/master/text/0031-pbft-node-catchup.md).)
 
 3. Wait for the node to catch up to the rest of the network (get within
    a few blocks of the chain head). If the new node becomes a PBFT

--- a/docs/1.2/sysadmin_guide/rest_auth_proxy.md
+++ b/docs/1.2/sysadmin_guide/rest_auth_proxy.md
@@ -34,7 +34,7 @@ this:
 
 ```json
 {
-  "link": "https://hyperledger.org/sawtooth/blocks?head=..."
+  "link": "https://splinter.dev/sawtooth/blocks?head=..."
 }
 ```
 
@@ -58,14 +58,14 @@ builds a link, it looks for the following types of \"X-Forwarded\"
 headers:
 
 -   `X-Forwarded-Host`: Domain name of the proxy server (for example,
-    `hyperledger.org`)
+    `splinter.dev`)
 -   `X-Forwarded-Proto`: Protocol/scheme used to make requests (for
     example, `https`)
 -   `X-Forwarded-Path`: Extra path information (for example,
     `/sawtooth`). This uncommon header is implemented by the REST API.
     It is necessary only if the proxy endpoints do not map directly to
     the REST API endpoints, that is, when
-    `hyperledger.org/sawtooth/blocks` does not map to
+    `splinter.dev/sawtooth/blocks` does not map to
     `localhost:8008/blocks`.
 
 ## \"Forwarded\" Headers
@@ -84,13 +84,13 @@ When the REST API builds a response link, it looks for the following
 keys:
 
 -   `host`: Domain name of the proxy server (for example,
-    `host=hyperledger.org`)
+    `host=splinter.dev`)
 -   `proto`: Protocol/scheme used to make requests (for example,
     `proto=https`)
 -   `path`: Extra path information (for example, `path="/sawtooth"`).
     This non-standard key header is necessary only if the proxy
     endpoints do not map directly to the REST API endpoints, that is,
-    when `hyperledger.org/sawtooth/blocks` does not map to
+    when `splinter.dev/sawtooth/blocks` does not map to
     `localhost:8008/blocks`.
 
 > **Note**

--- a/docs/1.2/sysadmin_guide/setting_up_sawtooth_network.md
+++ b/docs/1.2/sysadmin_guide/setting_up_sawtooth_network.md
@@ -56,9 +56,9 @@ following transaction processors:
 >
 > These instructions have been tested on Ubuntu 18.04 (Bionic) only.
 
-## Installing Hyperledger Sawtooth
+## Installing Sawtooth
 
-This procedure describes how to install Hyperledger Sawtooth on a Ubuntu
+This procedure describes how to install Sawtooth on a Ubuntu
 system for proof-of-concept or production use in a Sawtooth network.
 
 1.  Choose whether you want the stable version (recommended) or the most
@@ -351,7 +351,7 @@ in the initial network.
 
         For the available settings and their default values, see
         \"On-Chain Settings\" in the [Sawtooth PBFT
-        documentation](https://sawtooth.hyperledger.org/docs/#sawtooth-pbft).
+        documentation]({% link docs/1.2/pbft/configuring-pbft.md %}#on-chain-settings-label)
 
     -   For PoET:
 
@@ -366,8 +366,8 @@ in the initial network.
         > **Note**
         >
         > This example shows the default PoET settings. For more
-        > information, see the [Hyperledger Sawtooth Settings
-        > FAQ](https://sawtooth.hyperledger.org/faq/settings/).
+        > information, see the [Sawtooth Settings
+        > FAQ](https://sawtooth.splinter.dev/faq/settings.html).
 
 7.  As the sawtooth user, combine the separate batches into a single
     genesis batch that will be committed in the genesis block.
@@ -1090,10 +1090,10 @@ have joined the network before continuing.
 
 > **Tip**
 >
-> For help with problems, see the [Hyperledger Sawtooth
+> For help with problems, see the [Sawtooth
 > FAQ]({% link faq/index.md %}) or ask a question on the
-> Hyperledger Chat [#sawtooth
-> channel](https://chat.hyperledger.org/channel/sawtooth).
+> Discord [#sawtooth
+> channel](https://discord.gg/fnUmDv7tSH).
 
 After verifying that Sawtooth is running correctly, you can continue
 with the optional configuration and customization steps that are

--- a/docs/1.2/transaction_family_specifications/index.md
+++ b/docs/1.2/transaction_family_specifications/index.md
@@ -68,19 +68,13 @@ available in the `sawtooth-core` repository unless noted below.
     The family name is `xo`. The transaction processor is
     `xo-tp-{language}`.
 
-The following transaction families run on top of the Sawtooth platform:
+The following transaction family runs on top of the Sawtooth platform:
 
 -   [Sawtooth Sabre Transaction
     Family]({% link docs/1.2/sabre/sabre_transaction_family.md%}):
     Implements on-chain smart contracts that are executed in a
     WebAssembly (WASM) virtual machine. This transaction family is in
-    the [sawtooth-sabre](https://github.com/hyperledger/sawtooth-sabre)
-    repository.
--   [Sawtooth Seth Transaction
-    Family](https://sawtooth.hyperledger.org/docs/seth/nightly/master/):
-    Supports running Ethereum Virtual Machine (EVM) smart contracts on
-    Sawtooth. This transaction family is in the
-    [sawtooth-seth](https://github.com/hyperledger/sawtooth-seth)
+    the [sawtooth-sabre](https://github.com/splintercommunity/sawtooth-sabre)
     repository.
 
 <!--


### PR DESCRIPTION
This commit removes mentions and links to hyperledger
besides references to the docker images. The docker
images are currently left as is.

This also removes mentions of Seth and Raft. These
projects were previously archived and were not moved
over to splintercommunity.
