### PR TITLE
Build openapi files with redoc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 name: Build
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
   schedule:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,10 @@ jobs:
         with:
           ruby-version: '3.1.3'
           bundler-cache: true
+      - name: Install redoc
+        run: npm install -g redoc
+      - name: Install redoc-cli
+        run: npm install -g redoc-cli
       - name: Install Just
         run: sudo snap install --edge --classic just
       - name: Build

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -26,6 +26,10 @@ jobs:
           bundler-cache: true
       - name: Install Just
         run: sudo snap install --edge --classic just
+      - name: Install redoc
+        run: npm install -g redoc
+      - name: Install redoc-cli
+        run: npm install -g redoc-cli
       - name: Build
         run: just build
       - name: "Deploy to AWS S3"

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -1,6 +1,9 @@
-name: Deploy-to-splinter.splinter.dev
+name: Deploy-to-sawtooth.splinter.dev
 
 on:
+  push:
+    branches: [ main ]
+
   workflow_dispatch:
 
 concurrency:

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@ _site
 _userconfig.yml
 .idea
 .jekyll-cache/
+.jekyll-metadata
 
 docs/1.2/sdks/python_sdk
+docs/1.2/rest_api/api/

--- a/ci/website.dockerfile
+++ b/ci/website.dockerfile
@@ -49,17 +49,6 @@ RUN pydoc3 -w sawtooth_sdk/processor/* \
  && mkdir -p /tmp/python_sdk/signing \
  && cp *.html /tmp/python_sdk/signing
 
-# -------------=== redoc build ===-------------
-
-FROM node:lts-stretch as redoc
-
-RUN npm install -g redoc
-RUN npm install -g redoc-cli
-
-COPY . /project
-
-RUN redoc-cli bundle /project/docs/1.2/openapi.yaml -o index_1.2.html
-
 # -------------=== jekyll build ===-------------
 
 FROM jekyll/jekyll:3.8 as jekyll

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -51,19 +51,3 @@ services:
           && mkdir -p /srv/jekyll/docs/1.2/sdks/python_sdk/signing \
           && cp *.html /srv/jekyll/docs/1.2/sdks/python_sdk/signing \
         "
-
-  sawtooth-docs-redoc:
-    container_name: sawtooth-docs-redoc
-    image: sawtooth-docs-redoc
-    build:
-      dockerfile: docker/sawtooth-docs-redoc
-      context: .
-    ports:
-      - 4001:4001
-    volumes:
-      - .:/project
-    entrypoint: |
-      bash -c "
-        cd /project/docs/1.2/
-        redoc-cli serve openapi.yaml -h 0.0.0.0 -w -p 4001
-      "

--- a/docs/1.2/rest_api/index.md
+++ b/docs/1.2/rest_api/index.md
@@ -5,7 +5,7 @@
 
 # REST API Reference
 
-- [Endpoint Specifications](./openapi/)
+- [Endpoint Specifications]({%link docs/1.2/rest_api/api/index.html%})
 - [Error Responses]({%link docs/1.2/rest_api/error_codes.md%})
     - [HTTP Status Codes]({%link docs/1.2/rest_api/error_codes.md%}#http-status-codes)
     - [JSON Response]({%link docs/1.2/rest_api/error_codes.md%}#json-response)

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-# Copyright 2023 Bitwise IO, Inc.
+# Copyright 2023-2024 Bitwise IO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build:
+build: build-api
     #!/usr/bin/env sh
     set -e
 
@@ -25,10 +25,24 @@ build:
     bundle install
     bundle exec jekyll build
 
+build-api:
+    #!/usr/bin/env sh
+    set -e
+
+    cmd="redoc-cli build docs/1.2/openapi.yaml -o docs/1.2/rest_api/api/index.html"
+    echo "\033[1m$cmd\033[0m"
+    $cmd
+
+    echo
+    echo "** In MacOS: open docs/1.2/rest_api/api/index.html"
+
+    echo "\n\033[92mBuild API Success\033[0m\n"
+
 clean:
     rm -rf \
         .jekyll-metadata/ \
         _site/ \
+        docs/1.2/rest_api/api/ \
         Gemfile.lock
 
 install-jekyll-via-brew:
@@ -56,7 +70,7 @@ install-mdl:
 
     gem install mdl
 
-run:
+run: build-api
     #!/usr/bin/env sh
     set -e
 


### PR DESCRIPTION
This was previously omitted in the transition away from docker.

Also update the github actions to deploy on merge.