### PR TITLE
Remove leading / before redirect

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-redirect_to: /docs/1.2/
+redirect_to: docs/1.2/
 ---
 
 <!--


### PR DESCRIPTION
This doesn't work well with cloudfront because cloudfront does not proactively remove multiple "/".